### PR TITLE
Arreglos y mejoras al generar pdfs

### DIFF
--- a/infrastructure/documents.py
+++ b/infrastructure/documents.py
@@ -94,13 +94,13 @@ def save_document(company_id, key_mh, sign_xml, status, date, document_type, rec
         conn = mysql.connect()
         cursor = conn.cursor()
         cursor.callproc('sp_saveDocument', (company_id, key_mh, sign_xml, status, date, document_type,receiver_type,
-                                            receiver_dni, total_document, total_taxed, pdf, email, email_costs))
+                                            receiver_dni, total_document, total_taxed, pdf, email, email_costs,))
         data = cursor.rowcount
         if data != 0:
             conn.commit()
             return True
         else:
-            return json.dumps({'error': str(data[0])})
+            return json.dumps({'error': 'SP Call returned 0 affected rows (should have returned 1).'}) # this may happen when the document's key_mh is already in the database. Should prolly change the response message accordingly
     except Exception as e:
         return json.dumps({'error': str(e)})
     finally:
@@ -138,7 +138,7 @@ def save_document_line_info(id_company, line_number, quantity, unity
             conn.commit()
             return True
         else:
-            return json.dumps({'error': str(data[0])})
+            return json.dumps({'error': 'SP Call returned 0 affected rows.'})
     except Exception as e:
         return json.dumps({'error': str(e)})
     finally:

--- a/service/fe_enums.py
+++ b/service/fe_enums.py
@@ -101,11 +101,33 @@ tagNamePDF = {
 }
 
 tipoCedulaPDF = {
-    '01': 'fisica',
-    '02': 'juridica',
-    '03': 'dimex',
-    '04': 'nite',
-    '05': 'extranjero',
+    '01': 'Cédula Física',
+    '02': 'Cédula Jurídica',
+    '03': 'DIMEX',
+    '04': 'NITE',
+    '05': 'Cédula Extranjera', # <- this one is not mentioned as a valid value for the XML...
 }
 
 currencies = {'USD': '$', 'CRC': '₡', 'EUR': '€'}
+
+paymentMethods = {
+    '01' : 'Efectivo',
+    '02' : 'Tarjeta',
+    '03' : 'Cheque',
+    '04' : 'Transferencia - depósito bancario',
+    '05' : 'Recaudado por terceros',
+    '99' : 'Otro: '
+    }
+
+saleConditions = {
+    '01' : 'Contado',
+    '02' : 'Crédito',
+    '03' : 'Consignación',
+    '04' : 'Apartado',
+    '05' : 'Arrendamiento con opción de compra',
+    '06' : 'Arrendamiento en función financiera',
+    '07' : 'Cobro a favor de un tercero',
+    '08' : 'Servicios prestados al Estado a crédito',
+    '09' : 'Pago del servicios prestados al Estado',
+    '99' : 'Otros: '
+    }

--- a/service/makepdf.py
+++ b/service/makepdf.py
@@ -27,19 +27,28 @@ def render_pdf(company_data, document_type, key_mh, consecutive, date, sale_cond
     simboloMoneda = fe_enums.currencies[moneda['tipoMoneda']]
 
     total_document_words = utils.numToWord(total_document)
-    type_iden_receptor = fe_enums.tipoCedulaPDF[receptor['tipoIdentificacion']]
 
-    main_content = render_template("invoice.html",
-                                   key_mh=key_mh, company=company_data, lines=lines, total_document=total_document
-                                   , type_iden_receptor=type_iden_receptor
+    # @todo: how to get a proper description for code 99 (Others)?
+    payment_methods_desc = list(fe_enums.paymentMethods.get(pm.get('codigo'), 'Efectivo') for pm in payment_methods)
+    payment_methods_csvs = ', '.join(payment_methods_desc);
+
+    sale_condition_str = fe_enums.saleConditions.get(sale_conditions, 'No especificada')
+
+    re_idType_desc = fe_enums.tipoCedulaPDF.get(receptor.get('tipoIdentificacion'), 'Tipo de identificación no especificada')
+
+    main_content = render_template("invoice.html"
+                                   , key_mh=key_mh, lines=lines, total_document=total_document
                                    , total_taxes=total_impuestos, total_discounts=total_descuento
-                                   , total_sales=total_sales, receiver=receptor, payment_method=payment_methods
-                                   , sale_condition=sale_conditions, currency=moneda, currencySymbol=simboloMoneda
-                                   , activity_code=activity_code, total_document_words=total_document_words)
+                                   , total_sales=total_sales, receiver=receptor, payment_method=payment_methods_csvs
+                                   , sale_condition=sale_condition_str, currency=moneda, currencySymbol=simboloMoneda
+                                   , activity_code=activity_code, total_document_words=total_document_words
+                                   , date=date
+                                   , type_iden_receptor=re_idType_desc
+                                   , company=company_data[0])
     options = {
         '--encoding': 'utf-8'
     }
-    add_pdf_header(options, company_data[0], document_type, consecutive, date, logo)
+    add_pdf_header(options, company_data[0], document_type, consecutive, date, logo, key_mh)
     try:
         pdf = pdfkit.from_string(main_content, False, css=css, options=options)
     finally:
@@ -47,12 +56,12 @@ def render_pdf(company_data, document_type, key_mh, consecutive, date, sale_cond
     return pdf
 
 
-def add_pdf_header(options, company_data, document_type, consecutive, date,  logo):
+def add_pdf_header(options, company_data, document_type, consecutive, date,  logo, key_mh):
     with tempfile.NamedTemporaryFile(suffix='.html', delete=False) as header:
         options['--header-html'] = header.name
-        type_iden_company = fe_enums.tipoCedulaPDF[company_data['type_identification']]
+        type_iden_company = fe_enums.tipoCedulaPDF.get(company_data.get('type_identification'), 'Tipo de identificación no especificada')
         header.write(
             render_template("header.html", company=company_data, type_iden_company=type_iden_company,
-                            type=document_type, consecutive=consecutive, date=date, logo=logo).encode('utf-8')
+                            type=document_type, consecutive=consecutive, date=date, logo=logo, key_mh=key_mh).encode('utf-8')
         )
     return

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,77 +1,116 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
-<head>
-    <style>
-        .image{
-            margin-top:20px;
-            margin-right:20px;
-            max-width:150px;
-            max-height:150px;
-        }
-        .container{
-            font-size: 13px;
-        }
-    </style>
-    <div class="container">
-        <table class="table">
-            <tr>
-                <td>
-                    <img src="data:;base64,{{ logo }}" class="image"/>
-                </td>
-                <td>
-                    <table class="table table-sm">
-                        <tr>
-                            <td>
-                                {{company.name}}
-                            </td>
-                            <td>
-                                <b>{{type}}</b></br>
-                                {{consecutive}}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                C&eacutedula {{type_iden_company}}:{{company.identification_dni}}
-                            </td>
-                            <td>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                Tel&eacutefono: {{company.phone}}
-                            </td>
-                            <td>
-                                <b>Fecha:</b>{{date}}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
+    <head>
+        <meta charset="utf-8"/>
+    </head>
+    <body>
+        <style>
+            .image {
+                margin-top: 20px;
+                margin-right: 20px;
+                max-width: 150px;
+                max-height: 150px;
+            }
 
-                            </td>
-                            <td>
+			.container {
+				font-size: 0.85rem;
+			}
 
-                            </td>
-                        </tr>
-                         <tr>
-                            <td>
-                                Correo electr&oacutenico: {{company.email}}
-                            </td>
-                            <td>
+			.table {
+				font-size: 0.85rem;
+                margin-top: 20px;
+			}
 
-                            </td>
-                        </tr>
-                         <tr>
-                            <td>
-                                Direcci&oacuten: {{company.address}}
-                            </td>
-                            <td>
+			.text-left {
+				text-align: left !important
+			}
 
-                            </td>
-                        </tr>
-                    </table>
-                </td>
-            </tr>
+			.text-right {
+				text-align: right !important
+			}
 
-        </table>
-    </div>
-</head>
+			.header table {
+                font-size: 1rem
+			}
+
+			.invoice-info {
+                position: absolute;
+                top: 0;
+                right: 0;
+			}
+        </style>
+        <div class="container">
+            <table class="header table">
+                <tr>
+                    <td>
+                        <img src="data:;base64,{{ logo }}" class="image" />
+                    </td>
+                    <td>
+                        <table class="table table-sm">
+                            <tr>
+                                <td>
+                                    {{company.name}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    {{type_iden_company}}: {{company.identification_dni}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    Tel&eacutefono: {{company.phone}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                </td>
+                                <td>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    Correo electr&oacutenico: {{company.email}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    Direcci&oacuten: {{company.address}}
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                    <td>
+                        <table class="table table-sm invoice-info">
+                            <tr>
+                                <td>
+                                    <b>{{type}}</b><br>
+                                    {{consecutive}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <b>Fecha:</b> {{date}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </div>

--- a/templates/invoice.html
+++ b/templates/invoice.html
@@ -1,133 +1,128 @@
-<body>
-<style>
-        .container{
-            font-size: 13px;
-        }
-        .table{
-            font-size: 13px;
-        }
-    </style>
-</br>
-    <div class="container">
-        <table class="table table-sm">
-             <tr>
-                <td>
-                    <b>Clave del Comprobante:</b>
-                </td>
-                <td colspan="4">
-                    {{key_mh}}
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <b>Cliente:</b>
-                </td>
-                <td colspan="4">
-                    {{receiver.nombre}}
-                </td>
-            </tr>
-            <tr>
-                <td> <b>C&eacutedula {{type_iden_receptor}}:</b> </td>
-                <td colspan="2">
-                    {{receiver.numeroIdentificacion}}
-                </td>
-                <td> <b>Condici&oacuten de Venta:</b> </td>
-                <td>
-                   {{sale_condition}}
-                </td>
-            </tr>
-            <tr>
-                <td> <b>Tel&eacutefono:</b> </td>
-                <td colspan="2">
-                     {{receiver.telefono}}
-                </td>
-                <td> <b>Medio de Pago:</b> </td>
-                <td>
-                   {{payment_method.codigo}}
-                </td>
-            </tr>
-            <tr>
-                <td> <b>Correo:</b> </td>
-                <td colspan="2">
-                     {{receiver.correo}}
-                </td>
-                <td> <b>Moneda:</b> </td>
-                <td>
-                  {{currency.tipoMoneda}}
-                </td>
-            </tr>
-            <tr>
-                <td> <b>Direcci&oacuten:</b> </td>
-                <td colspan="2">
-                    {{receiver.otrasSenas}}
-                </td>
-                <td> <b>Act. Economica:</b> </td>
-                <td>
-                  {{activity_code}}
-                </td>
-            </tr>
-        </table>
-        <table class="table table-sm table-striped">
-            <thead class="thead-dark">
-                <th scope="col">C&oacutedigo</th>
-                <th scope="col">Producto</th>
-                <th scope="col">Cantidad</th>
-                <th scope="col">Precio</th>
-                <th scope="col">Impuestos</th>
-                <th scope="col">Total</th>
-            </thead>
-            <tbody>
-            {%for line in lines %}
-            <tr>
-                    <td scope="row">{{line.codigo_comercial}}</td>
-                    <td>{{line.detalle}}</td>
-                    <td>{{line.cantidad}}</td>
-                    <td>{{line.precioUnitario}}</td>
-                    <td>{{line.impuestoNeto}}</td>
-                    <td>{{line.subtotal}}</td>
-            </tr>
-            {%endfor%}
+﻿		<br>
+		<div class="container">
+			<table class="table table-sm">
+				<tr>
+					<td>
+						<b>Clave del Comprobante:</b>
+					</td>
+					<td colspan="4">
+						{{key_mh}}
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<b>Cliente:</b>
+					</td>
+					<td colspan="4">
+						{{receiver.nombre}}
+					</td>
+				</tr>
+				<tr>
+					<td> <b>{{type_iden_receptor}}:</b> </td>
+					<td colspan="2">
+						{{receiver.numeroIdentificacion}}
+					</td>
+					<td> <b>Condici&oacuten de Venta:</b> </td>
+					<td>
+						{{sale_condition}}
+					</td>
+				</tr>
+				<tr>
+					<td> <b>Tel&eacutefono:</b> </td>
+					<td colspan="2">
+						{{receiver.telefono}}
+					</td>
+					<td> <b>Medio(s) de Pago:</b> </td>
+					<td>
+						{{payment_method}}
+					</td>
+				</tr>
+				<tr>
+					<td> <b>Correo:</b> </td>
+					<td colspan="2">
+						{{receiver.correo}}
+					</td>
+					<td> <b>Moneda:</b> </td>
+					<td>
+						{{currency.tipoMoneda}}
+					</td>
+				</tr>
+				<tr>
+					<td> <b>Direcci&oacuten:</b> </td>
+					<td colspan="2">
+						{{receiver.otrasSenas}}
+					</td>
+					<td> <b>Act. Ecónomica:</b> </td>
+					<td>
+						{{activity_code}}
+					</td>
+				</tr>
+			</table>
+			<table class="table table-sm table-striped">
+				<thead class="thead-dark">
+					<tr>
+						<th scope="col" class="text-left">C&oacutedigo</th>
+						<th scope="col" class="text-left">Producto</th>
+						<th scope="col" class="text-right">Cantidad</th>
+						<th scope="col" class="text-right">Precio</th>
+						<th scope="col" class="text-right">Impuestos</th>
+						<th scope="col" class="text-right">Total</th>
+					</tr>
+				</thead>
+				<tbody>
+					{%for line in lines %}
+					<tr>
+						<td scope="row" class="text-left">{{line.codigo_comercial}}</td>
+						<td class="text-left">{{line.detalle}}</td>
+						<td class="text-right">{{line.cantidad}}</td>
+						<td class="text-right">{{line.precioUnitario}}</td>
+						<td class="text-right">{{line.impuestoNeto}}</td>
+						<td class="text-right">{{line.subtotal}}</td>
+					</tr>
+					{%endfor%}
 
-            </tbody>
-        </table>
-        <div style="text-align: center"><p> ****** Ultima Linea *******</p></div>
-        <table class="table table-sm">
-            <tr>
-                <td>
-                    {{total_document_words}}
-                </td>
-                <td>
-                <table class="table">
-                    <tr>
-                        <td scope="row">Sub Total:</td>
-                        <td>{{currencySymbol}} {{total_sales}}</td>
-                    </tr>
-                    <tr>
-                        <td scope="row">Descuento:</td>
-                        <td>{{currencySymbol}} {{total_discounts}}</td>
-                    </tr>
-                    <tr>
-                        <td scope="row">IVA:</td>
-                        <td>{{currencySymbol}} {{total_taxes}}</td>
-                    </tr>
-                    <tr>
-                        <td scope="row">Total Factura:</td>
-                        <td>{{currencySymbol}} {{total_document}}</td>
-                    </tr>
-                </table>
-            </td>
-            </tr>
+				</tbody>
+			</table>
+			<div style="text-align: center"><p> ****** Ultima Linea *******</p></div>
+			<table class="table table-sm">
+				<tr>
+					<td>
+						{{total_document_words}}
+					</td>
+					<td>
+						<table class="table">
+							<tr>
+								<td scope="row">Sub Total:</td>
+								<td>{{currencySymbol}} {{total_sales}}</td>
+							</tr>
+							<tr>
+								<td scope="row">Descuento:</td>
+								<td>{{currencySymbol}} {{total_discounts}}</td>
+							</tr>
+							<tr>
+								<td scope="row">IVA:</td>
+								<td>{{currencySymbol}} {{total_taxes}}</td>
+							</tr>
+							<tr>
+								<td scope="row">Total Factura:</td>
+								<td>{{currencySymbol}} {{total_document}}</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
 
-        </table>
-    </div>
-</body>
-<footer>
-    <div class="container">
-        <p>Este documento constituye factura comercial con titulo ejecutivo de acuerdo al art. 460 del C&oacutedigo de Comercio que podr&aacute
-hacerse efectivo el d&iacutea de su vencimiento y en caso de ejecuci&oacuten, renuncio a mi domicilio y los tr&aacutemites de juicio ejecutivo.
-CONFIRMACIONES: Para enviar confirmaciones de dep&oacutesito Correo: {{company.email}}</p>
-        <b>Observaciones:</b>
-        <p style="text-align:center">Autorizado mediante la Resolucion Version:  Fact Elec.</p>
-    </div>
-</footer>
+			</table>
+		</div>
+		<footer>
+			<div class="container">
+				<p>
+					Este documento constituye factura comercial con titulo ejecutivo de acuerdo al art. 460 del C&oacutedigo de Comercio que podr&aacute
+					hacerse efectivo el d&iacutea de su vencimiento y en caso de ejecuci&oacuten, renuncio a mi domicilio y los tr&aacutemites de juicio ejecutivo.
+					CONFIRMACIONES: Para enviar confirmaciones de dep&oacutesito Correo: {{company.email}}
+				</p>
+				<b>Observaciones:</b>
+				<p style="text-align:center">Autorizado mediante la Resolucion Version:  Fact Elec.</p>
+			</div>
+		</footer>
+	</body>
 </html>


### PR DESCRIPTION
- Se incluyeron nuevos enumeradores para el texto que correspondiente
texto de los codigos de "Medio de Pago" y "Condicion de Venta", y se
ajusto el enum de tipoCedulaPDF para que contenga toda la frase completa
del tipo de identificación correspondiente.
- Se ajusto el formato de las plantillas html para que la indentacion
sea adecuada y se hicieron algunos arreglos en la estructura html.