### PR TITLE
Arreglos a creacion de factura y pdf

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -23,9 +23,9 @@ def build_response_data(result: dict, warn_msg: str = 'No data was found', error
 
     if 'error' in result:
         error = result['error']
-        response['http_status'] = result['http_status'] if 'http_status' in result else 500
-        response['status'] = error['code'] if 'code' in error else 400
-        response['error'] = error['message'] if 'message' in error else error_msg
+        response['http_status'] = result.get('http_status', error.get('http_status', 500))
+        response['status'] = error.get('code', error.get('status', 400))
+        response['details'] = error.get('message', error.get('details', error_msg))
         if 'debug' in error:
             response['debug'] = error['debug']
     elif 'data' in result:
@@ -34,11 +34,11 @@ def build_response_data(result: dict, warn_msg: str = 'No data was found', error
             response['data'] = data
         else:
             response['message'] = warn_msg
-    elif 'message' in result:
+    
+    if 'message' in result:
         message = result['message']
         response['message'] = message if message else warn_msg
-    else:
-        response['message'] = warn_msg
+
 
     if 'headers' in result:
         headers = result['headers']

--- a/service/api_facturae.py
+++ b/service/api_facturae.py
@@ -626,30 +626,30 @@ def other_charges(sb, otrosCargos):
     sb.Append('<OtrosCargos>')
     for otro_cargo in otrosCargos:
         sb.Append('<TipoDocumento>' +
-                  otrosCargos[otro_cargo]['tipoDocumento'] +
+                  otro_cargo['tipoDocumento'] +
                   '</TipoDocumento>')
 
-        if otrosCargos[otro_cargo].get('numeroIdentidadTercero'):
+        if otro_cargo.get('numeroIdentidadTercero'):
             sb.Append('<NumeroIdentidadTercero>' +
-                      str(otrosCargos[otro_cargo]['numeroIdentidadTercero']) +
+                      str(otro_cargo['numeroIdentidadTercero']) +
                       '</NumeroIdentidadTercero>')
 
-        if otrosCargos[otro_cargo].get('nombreTercero'):
+        if otro_cargo.get('nombreTercero'):
             sb.Append('<NombreTercero>' +
-                      otrosCargos[otro_cargo]['nombreTercero'] +
+                      otro_cargo['nombreTercero'] +
                       '</NombreTercero>')
 
         sb.Append('<Detalle>' +
-                  otrosCargos[otro_cargo]['detalle'] +
+                  otro_cargo['detalle'] +
                   '</Detalle>')
 
-        if otrosCargos[otro_cargo].get('porcentaje'):
+        if otro_cargo.get('porcentaje'):
             sb.Append('<Porcentaje>' +
-                      str(otrosCargos[otro_cargo]['porcentaje']) +
+                      str(otro_cargo['porcentaje']) +
                       '</Porcentaje>')
 
         sb.Append('<MontoCargo>' +
-                  str(otrosCargos[otro_cargo]['montoCargo']) +
+                  str(otro_cargo['montoCargo']) +
                   '</MontoCargo>')
     sb.Append('</OtrosCargos>')
 

--- a/service/api_facturae.py
+++ b/service/api_facturae.py
@@ -533,7 +533,7 @@ def lines_xml(sb, lines, document_type, receiver_company):
         if document_type == 'FEE' and v.get('partidaArancelaria'):
             sb.Append('<PartidaArancelaria>' + str(v['partidaArancelaria']) + '</PartidaArancelaria>')
 
-        code = v.get('codigo',v.get('codigoServicio',v.get('codigoProducto'))) # just in case...
+        code = v.get('cabys', v.get('codigo', v.get('codigoServicio', v.get('codigoProducto')))) # just in case...
         if isinstance(code, str):
             sb.Append('<Codigo>' + code + '</Codigo>')
 
@@ -754,7 +754,8 @@ def gen_xml_v43(company_data, document_type, key_mh, consecutive, date, sale_con
     sb.Append('<TotalDescuentos>' + str(total_descuento) + '</TotalDescuentos>')
     sb.Append('<TotalVentaNeta>' + str(base_total) + '</TotalVentaNeta>')
     sb.Append('<TotalImpuesto>' + str(total_impuestos) + '</TotalImpuesto>')
-    sb.Append('<TotalIVADevuelto>' + str(total_return_iva) + '</TotalIVADevuelto>')
+    if document_type not in ('FEC', 'FEE'): # change this to a constant or something
+        sb.Append('<TotalIVADevuelto>' + str(total_return_iva) + '</TotalIVADevuelto>')
     sb.Append('<TotalOtrosCargos>' + str(totalOtrosCargos) + '</TotalOtrosCargos>')
     sb.Append('<TotalComprobante>' + str(total_document) + '</TotalComprobante>')
     sb.Append('</ResumenFactura>')
@@ -864,7 +865,7 @@ def send_xml_fe(_company, _receptor, _key_mh, token, date, xml, env):
     # xml is coming as bytes: json.dumps cannot serialize bytes by default, so let's try converting it to a string
     if isinstance(xml, bytes):
         # assuming this has to already be a b64 encoded byte-like object
-        xml = xml.decode('utf-8');
+        xml = xml.decode('utf-8')
 
     data = {'clave': _key_mh,
             'fecha': date,

--- a/service/api_facturae.py
+++ b/service/api_facturae.py
@@ -1016,12 +1016,30 @@ def consulta_clave(clave, token, tipo_ambiente): # duplicated in utils_mh... are
             'ind-estado': response.json().get('ind-estado'),
             'respuesta-xml': response.json().get('respuesta-xml')
         }
-    #elif 400 <= response.status_code <= 499: # don't know the purpose of this?
-       # response_json = {'status': 400, 'ind-estado': 'error'}
+    elif 400 <= response.status_code <= 499: # now I know, but making it better?
+        cause = response.headers.get('X-Error-Cause')
+        if not cause:
+            cause = 'Error'
+            _logger.warning("""**Undocumented Hacienda response:**
+            Endpoint: {}
+            Http Status: {}
+            Request Headers: {}
+            Response Headers: {}
+            Response Body: {}
+            """.format(endpoint, response.status_code,
+                       str(response.request.headers),
+                       str(response.headers), response.text))
+        response_json = {'status': response.status_code, 'ind-estado': cause}
     else:
         _logger.error("""MAB - consulta_clave failed.
         Status code: {}
-        Reason: {}""".format(response.status_code, response.reason))
+        Reason: {}
+        Request Headers: {}
+        Response Headers: {}
+        Response Body: {}
+        """.format(response.status_code, response.reason,
+                   str(response.request.headers),
+                   str(response.headers), response.text))
         raise ServerError(status=InternalErrorCodes.INTERNAL_ERROR)
     return response_json
 

--- a/templates/invoice.html
+++ b/templates/invoice.html
@@ -108,12 +108,12 @@
 				{%for line in lines %}
 				<tr>
 					<td scope="row" class="text-left">{{line.numero}}</td>
-					<td class="text-left">{{line.codigo}}</td>
+					<td class="text-left">{{line.cabys}}</td>
 					<td class="text-left">{{line.detalle}}</td>
 					<td class="text-right">{{line.cantidad}}</td>
 					<td class="text-right">{{line.precioUnitario}}</td>
 					<td class="text-right">{{line.impuestoNeto}}</td>
-					<td class="text-right">{{line.impuesto[0].tarifa|int}}</td>
+					<td class="text-right">{% if line.impuesto %}{{line.impuesto[0].tarifa|int}}{% else %}0{% endif %}</td>
 					<td class="text-right">{{line.totalLinea}}</td>
 				</tr>
 				{%endfor%}


### PR DESCRIPTION
-Se encontro un caso de rechazo de hacienda el cual se produce
cuando una factura de tipo FEC ó FEE incluye en el XML la etiqueta
TotalIVADevuelto. Se aplico un arreglo temporal.
-Se encontro un error fatal producido cuando el documento no
incluye etiqueta de impuesto para la linea de detalle al crear el pdf.
Se aplico un arreglo por revisar.
Se implemento una nueva etiqueta a buscar para codigos cabys en
el xml y se implemento visualizacion de codigo cabys en el pdf.